### PR TITLE
 fix: tar archive extraction issue

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -56,7 +56,7 @@ install_version() {
   (
     mkdir -p "$install_path/bin"
     download_release "$version" "$release_file"
-    tar -xf "$release_file" -C "$install_path/bin" --strip-components=1 || fail "Could not extract $release_file"
+    tar -xf "$release_file" -C "$install_path/bin" || fail "Could not extract $release_file"
     chmod +x "$release_file"
 
     local tool_cmd


### PR DESCRIPTION
@SiegfriedEhret  This will fix the below error in the latest release - v0.7.9
![2021-11-23 19_40_31-~](https://user-images.githubusercontent.com/40381766/143042428-3d32aaed-de32-4137-9913-01834a0dfdb6.png)

