### PR TITLE
Update download URLs to match the new format

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,13 +40,13 @@ download_release() {
   local arch; arch=$(uname -m | tr '[:upper:]' '[:lower:]')
   case ${arch} in
   arm64)
-    url="$GH_REPO/releases/download/v${version}/zoxide-v${version}-aarch64-unknown-linux-musl.tar.gz"
+    url="$GH_REPO/releases/download/v${version}/zoxide-${version}-aarch64-unknown-linux-musl.tar.gz"
     ;;
   armv7l)
-    url="$GH_REPO/releases/download/v${version}/zoxide-v${version}-armv7-unknown-linux-musleabihf.tar.gz"
+    url="$GH_REPO/releases/download/v${version}/zoxide-${version}-armv7-unknown-linux-musleabihf.tar.gz"
     ;;
   x86_64)
-    url="$GH_REPO/releases/download/v${version}/zoxide-v${version}-x86_64-unknown-linux-musl.tar.gz"
+    url="$GH_REPO/releases/download/v${version}/zoxide-${version}-x86_64-unknown-linux-musl.tar.gz"
     ;;
   esac
 


### PR DESCRIPTION
Zoxide changed the release naming format with version 0.8.2 [ref](https://github.com/ajeetdsouza/zoxide/releases/tag/v0.8.2). The plugin couldn't download the new versions as it couldn't find them.

This PR just changes the `zoxide-v${version}` to `zoxide-${version}` (just removed three v's).