### PR TITLE
Fix install on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ jobs:
     name: asdf plugin test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: zoxide --version

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -75,8 +75,9 @@ install_version() {
     fail "asdf-$TOOL_NAME supports release installs only"
   fi
 
-  local release_file="$install_path/bin/$TOOL_NAME"
+  local release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$version.tar.gz"
   (
+    mkdir -p "$ASDF_DOWNLOAD_PATH"
     mkdir -p "$install_path/bin"
     download_release "$version" "$release_file"
     tar -xf "$release_file" -C "$install_path/bin" || fail "Could not extract $release_file"


### PR DESCRIPTION
Hi there, thanks for providing a zoxide plugin for asdf!

I was trying to run the installer on a Macbook, and it failed because BSD's tar doesn't allow extracting the exact location of the tar. So, I enabled the GitHub actions to build to run on macos, and changed the download location, making it compatible with macos devices.

